### PR TITLE
Improvement: Expand Roles and Personas in Documentation

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,144 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## Release Manager
+
+### Role Summary
+Oversees release planning and deployment coordination, collaborating with PM and DevOps to ensure smooth transitions from development to production.
+
+### Responsibilities
+- Plan and coordinate release windows and cycles across projects
+- Manage risks and resolve issues that affect release scope, schedule, and quality
+- Lead "Go/No-Go" meetings and coordinate deployment activities
+- Communicate release status and schedules to business stakeholders
+
+### Goals
+- Ensure release stability and reliability
+- Maintain a consistent and predictable release cadence
+- Minimize production incidents and downtime during deployments
+
+### Typical Communication
+- Release planning and coordination syncs
+- Deployment notifications and "Go/No-Go" communications
+- Post-release verification check-ins
+
+---
+
+## Business Analyst
+
+### Role Summary
+Gathers and analyzes business requirements, ensuring alignment between stakeholders and the delivery team to translate business needs into technical specifications.
+
+### Responsibilities
+- Elicit and document detailed business and functional requirements
+- Map business processes and identify gaps or improvement areas
+- Assist Product Managers in backlog grooming and requirement validation
+- Act as a bridge between stakeholders and the technical team
+
+### Goals
+- Ensure technical solutions meet business objectives
+- Improve the clarity and quality of requirements
+- Reduce rework by validating needs early in the lifecycle
+
+### Typical Communication
+- Requirement gathering workshops
+- Backlog refinement sessions
+- Stakeholder interviews and validation meetings
+
+---
+
+## DevOps Engineer
+
+### Role Summary
+Manages CI/CD pipelines, infrastructure automation, and deployment quality to ensure high availability and delivery efficiency.
+
+### Responsibilities
+- Build and maintain automated deployment pipelines
+- Manage cloud infrastructure and environment provisioning
+- Implement monitoring, logging, and alerting systems
+- Support Developers and Release Managers in troubleshooting environment issues
+
+### Goals
+- Achieve high deployment frequency and stability
+- Reduce manual overhead through automation
+- Ensure infrastructure security and scalability
+
+### Typical Communication
+- Infrastructure-as-Code reviews
+- Incident response and post-mortem syncs
+- Collaboration on CI/CD improvements with Developers
+
+---
+
+## Customer Support Lead
+
+### Role Summary
+Aggregates user feedback and incidents to communicate support needs to Product/Project Managers, helping prioritize post-release fixes and improvements.
+
+### Responsibilities
+- Monitor and report on production incidents and customer pain points
+- Provide feedback to Product Managers on feature usability and bugs
+- Coordinate support readiness for new releases
+- Guide the prioritization of bug fixes based on customer impact
+
+### Goals
+- Reduce the volume of support tickets through product improvements
+- Ensure high customer satisfaction and rapid issue resolution
+- Bridge the gap between end-users and the development team
+
+### Typical Communication
+- Support-to-Product feedback sessions
+- Incident triage and status updates
+- Release readiness briefings
+
+---
+
+## Subject Matter Expert (SME)
+
+### Role Summary
+Provides domain-specific insights and validation for requirements and design, ensuring that the solution aligns with industry or organizational standards.
+
+### Responsibilities
+- Provide expert advice on specific domains (e.g., legal, security, finance)
+- Review and validate requirements, designs, and prototypes
+- Participate in project reviews to ensure domain alignment
+- Assist in user acceptance testing (UAT) from a domain perspective
+
+### Goals
+- Ensure domain accuracy and compliance
+- Prevent design errors related to specialized knowledge
+- Enhance the overall quality and relevance of the solution
+
+### Typical Communication
+- Design and requirement review sessions
+- Ad-hoc consultations on domain-specific questions
+- UAT feedback and validation meetings
+
+---
+
+## UX Designer
+
+### Role Summary
+Maps user experiences and creates wireframes and prototypes, collaborating with Product Managers and Developers to ensure usability and high design quality.
+
+### Responsibilities
+- Conduct user research and usability testing
+- Create user flows, wireframes, and high-fidelity prototypes
+- Collaborate with Developers to ensure design feasibility and implementation
+- Define and maintain design systems and UI patterns
+
+### Goals
+- Create intuitive and engaging user experiences
+- Ensure consistency in design across the product
+- Validate design decisions through user testing and data
+
+### Typical Communication
+- Design critiques and handoff sessions
+- User research interviews and findings presentations
+- Collaboration with Product Managers on user journeys
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-


### PR DESCRIPTION
This PR expands the project management documentation by adding several key roles and personas to `docs/octoacme-roles-and-personas.md`. These additions enhance clarity and accountability by defining responsibilities, goals, and communication patterns for:

- Release Manager
- Business Analyst
- DevOps Engineer
- Customer Support Lead
- Subject Matter Expert
- UX Designer

Closes #4